### PR TITLE
Terminus intercept

### DIFF
--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -50,8 +50,8 @@ endfunction
 
 function! Terminus.InterceptCommand()
   let l:command = self.GetCommand()
-  call self.ClearCommand()
   if strlen(l:command) > 1 && l:command[0] ==# ":"
+    call self.ClearCommand()
     redir! => l:output
     execute l:command[1:]
     redir END
@@ -59,6 +59,7 @@ function! Terminus.InterceptCommand()
   else
     " run current command
     call jobsend(self.job_id, "")
+    startinsert
   endif
 endfunction
 

--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -50,15 +50,12 @@ endfunction
 
 function! Terminus.InterceptCommand()
   let l:command = self.GetCommand()
+  call self.ClearCommand()
   if strlen(l:command) > 1 && l:command[0] ==# ":"
-    call self.ClearCommand()
-    " TODO output to scratch buffer?
     redir! => l:output
     execute l:command[1:]
     redir END
-    " we want to pass each line as an item in a list for the setline() function
-
-    call self.OpenScratch([l:command] + split(strtrans(l:output), '\^@'))
+    " call self.OpenScratch([l:command] + split(strtrans(l:output), '\^@'))
   else
     " run current command
     call jobsend(self.job_id, "")
@@ -256,7 +253,7 @@ endfunction
 
 " Mappings
 tnoremap <silent> <Plug>TerminusEditCommand <c-\><c-n>:call <SID>current_terminal().EditCommand()<cr>
-tnoremap <silent> <Plug>TerminusInterceptCommand <c-\><c-n>:call <SID>current_terminal().InterceptCommand()<cr>A
+tnoremap <silent> <Plug>TerminusInterceptCommand <c-\><c-n>:call <SID>current_terminal().InterceptCommand()<cr>
 
 if get(g:, 'terminus_default_mappings', 0)
   tmap <c-x> <Plug>TerminusEditCommand

--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -48,6 +48,23 @@ function! Terminus.ClearCommand()
   endwhile
 endfunction
 
+function! Terminus.InterceptCommand()
+  let l:command = self.GetCommand()
+  if strlen(l:command) > 1 && l:command[0] ==# ":"
+    call self.ClearCommand()
+    " TODO output to scratch buffer?
+    redir! => l:output
+    execute l:command[1:]
+    redir END
+    " we want to pass each line as an item in a list for the setline() function
+
+    call self.OpenScratch([l:command] + split(strtrans(l:output), '\^@'))
+  else
+    " run current command
+    call jobsend(self.job_id, "")
+  endif
+endfunction
+
 function! Terminus.EditCommand()
   let l:command = self.GetCommand()
   call self.OpenScratch(l:command)
@@ -237,9 +254,11 @@ endfunction
 
 " Mappings
 tnoremap <silent> <Plug>TerminusEditCommand <c-\><c-n>:call <SID>current_terminal().EditCommand()<cr>
+tnoremap <silent> <Plug>TerminusInterceptCommand <c-\><c-n>:call <SID>current_terminal().InterceptCommand()<cr>A
 
 if get(g:, 'terminus_default_mappings', 0)
   tmap <c-x> <Plug>TerminusEditCommand
+  tmap <cr> <Plug>TerminusInterceptCommand
 endif
 
 " Commands

--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -67,8 +67,16 @@ endfunction
 
 function! Terminus.EditCommand()
   let l:command = self.GetCommand()
-  call self.OpenScratch(l:command)
   call self.ClearCommand()
+  call self.OpenScratch(l:command)
+
+  " send command back to terminal when we leave this buffer. Note that we
+  " can't use arguments in autocmd as they won't exist when autocmd is run so
+  " we must use execute to resolve those arguments beforehand
+  execute 'autocmd BufUnload <buffer> 
+        \ call g:terminus_terminals[' . self.bufnr . '].SetCommand(join(getline(0, ''$''), "\n"))
+        \ | autocmd! BufUnload <buffer>'
+
 endfunction
 
 function! Terminus.SetCommand(command)
@@ -111,12 +119,6 @@ function! Terminus.OpenScratch(command)
   setlocal bufhidden=unload
   setlocal noswapfile
 
-  " send command back to terminal when we leave this buffer. Note that we
-  " can't use arguments in autocmd as they won't exist when autocmd is run so
-  " we must use execute to resolve those arguments beforehand
-  execute 'autocmd BufUnload <buffer> 
-        \ call g:terminus_terminals[' . self.bufnr . '].SetCommand(join(getline(1, ''$''), "\n"))
-        \ | autocmd! BufUnload <buffer>'
 
   call setline(1, a:command)
 


### PR DESCRIPTION
Intercept commands from the command line beginning with `:` and execute them within Neovim. Useful for opening files within the current Neovim instance (`:e somefile`) or viewing the buffer list (`:ls`).
