### PR TITLE
Set scratch buffer filetype to terminus

### DIFF
--- a/plugin/terminus.vim
+++ b/plugin/terminus.vim
@@ -153,6 +153,7 @@ function! Terminus.OpenScratch(command)
 
   " make buffer a scratch buffer
   setlocal buftype=nofile
+  setlocal filetype=terminus
   setlocal bufhidden=unload
   setlocal noswapfile
   nnoremap <buffer> <c-x> :bdelete<cr>A


### PR DESCRIPTION
This would allow setting custom settings without worrying about conflicting with anything else

buffer type `nofile` might be used by other plugins